### PR TITLE
DRFT-68 clean up drift-dev-setup

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -15,7 +15,7 @@ cd insights-ingress-go
 docker build . -t ingress:latest
 cd ..
 
-# ingress build
+# puptoo build
 git clone https://github.com/RedHatInsights/insights-puptoo.git
 cd insights-puptoo
 docker build . -t puptoo:latest

--- a/full-stack-local-kerlescan.yml
+++ b/full-stack-local-kerlescan.yml
@@ -32,24 +32,11 @@ services:
       - 8000:8000 #for prometheus endpoint
     environment:
       - LOG_LEVEL=DEBUG
-# The following are temporary until insights-puptoo PR#77
-# gets merged.  Once merged, remove the INVENTORY_TOPIC
-# and ACG_CONFIG environment variables, as well as the
-# 'volumes' section below.
-      - INVENTORY_TOPIC=platform.inventory.host-ingress
-      - ACG_CONFIG=/cdappconfig.json
     depends_on:
       - kafka
-    volumes:
-      - type: bind
-        source: ../insights-puptoo/cdappconfig.json
-        target: /cdappconfig.json
   minio:
       image: minio/minio
       command: server /data
-      volumes:
-        - '$MINIO_DATA_DIR:/data:Z'
-        - '$MINIO_CONFIG_DIR:/root/.minio:Z'
       ports:
         - 9000:9000
       environment:

--- a/full-stack.yml
+++ b/full-stack.yml
@@ -32,24 +32,11 @@ services:
       - 8000:8000 #for prometheus endpoint
     environment:
       - LOG_LEVEL=DEBUG
-# The following are temporary until insights-puptoo PR#77
-# gets merged.  Once merged, remove the INVENTORY_TOPIC
-# and ACG_CONFIG environment variables, as well as the
-# 'volumes' section below.
-      - INVENTORY_TOPIC=platform.inventory.host-ingress
-      - ACG_CONFIG=/cdappconfig.json
     depends_on:
       - kafka
-    volumes:
-      - type: bind
-        source: ../insights-puptoo/cdappconfig.json
-        target: /cdappconfig.json
   minio:
       image: minio/minio
       command: server /data
-      volumes:
-        - '$MINIO_DATA_DIR:/data:Z'
-        - '$MINIO_CONFIG_DIR:/root/.minio:Z'
       ports:
         - 9000:9000
       environment:


### PR DESCRIPTION
DRFT-68: This cleans up the previous temp fix for puptoo clowder support breaking our setup.