### PR TITLE
Adds USE_CLOUD env variable for insights-proxy config

### DIFF
--- a/full-stack-local-kerlescan.yml
+++ b/full-stack-local-kerlescan.yml
@@ -295,6 +295,7 @@ services:
       - LINUX=True
       - PLATFORM=linux
       - CUSTOM_CONF=true
+      - USE_CLOUD=true # for cloud.redhat.com resources instead of console.redhat.com
     links:
       - "drift-frontend"
       - "inventory-rest"

--- a/full-stack.yml
+++ b/full-stack.yml
@@ -279,6 +279,7 @@ services:
       - LINUX=True
       - PLATFORM=linux
       - CUSTOM_CONF=true
+      - USE_CLOUD=true # for cloud.redhat.com resources instead of console.redhat.com
     links:
       - "drift-frontend"
       - "inventory-rest"


### PR DESCRIPTION
This is needed to access envirnments running on cloud.redhat.com
instead of on console.redhat.com.

See https://github.com/RedHatInsights/insights-proxy/blob/31b6681252e38279d7c3ab83cd7eee59ed6f0d63/README.md#run-the-container-with-cloud-proxy