### PR TITLE
Adds BYPASS_RBAC to inventory services

### DIFF
--- a/full-stack-local-kerlescan.yml
+++ b/full-stack-local-kerlescan.yml
@@ -102,6 +102,7 @@ services:
     environment:
       - INVENTORY_DB_HOST=db
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - BYPASS_RBAC=true
     links:
       - db
     depends_on:
@@ -121,6 +122,7 @@ services:
       - KAFKA_TOPIC=platform.system-profile
       - KAFKA_GROUP=inventory
       - WEB_CONCURRENCY=1
+      - BYPASS_RBAC=true
     links:
       - db
     depends_on:

--- a/full-stack.yml
+++ b/full-stack.yml
@@ -102,6 +102,7 @@ services:
     environment:
       - INVENTORY_DB_HOST=db
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+      - BYPASS_RBAC=true
     links:
       - db
     depends_on:
@@ -121,6 +122,7 @@ services:
       - KAFKA_TOPIC=platform.system-profile
       - KAFKA_GROUP=inventory
       - WEB_CONCURRENCY=1
+      - BYPASS_RBAC=true
     links:
       - db
     depends_on:


### PR DESCRIPTION
This switches off RBAC calls.

We need this as the default was changed in https://github.com/RedHatInsights/insights-host-inventory/pull/979